### PR TITLE
HH-59458 use raw protobuf objects for logging

### DIFF
--- a/protoctor/channel.py
+++ b/protoctor/channel.py
@@ -77,7 +77,7 @@ class RpcChannel(object):
                 self.logger.info(
                     'Decoded protobuf response from %s in %.2fms',
                     response.request.url, (time.time() - decode_start_time) * 1000,
-                    extra={'_text': str(rc)}
+                    extra={'_protobuf': rc}
                 )
 
             done(rc)

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,9 @@ setup(
     packages=['protoctor'],
     cmdclass={'build_py': BuildHook, 'test': TestHook},
     install_requires=[
-        'nose', 'pep8', 'hhwebutils'
+        'nose', 'hhwebutils'
+    ],
+    tests_require=[
+        'pep8 < 1.6'
     ]
 )


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-59458
при логировании передавать несериализованные протобуф-объекты